### PR TITLE
Add support for path syntax coloring

### DIFF
--- a/handlebars-mode.el
+++ b/handlebars-mode.el
@@ -123,10 +123,10 @@
 (defconst handlebars-mode-variable (concat "\\({{{?\s*"
                                     handlebars-mode-handlebars-token
                                     "\s*}}}?\\)"))
-(defconst handlebars-mode-variable-path (concat "\\({{./\s*"
+(defconst handlebars-mode-variable-path (concat "\\({{\s*./\s*"
                                     handlebars-mode-handlebars-token
                                     "\s*}}\\)"))
-(defconst handlebars-mode-variable-path-parent (concat "\\({{../\s*"
+(defconst handlebars-mode-variable-path-parent (concat "\\({{\s*../\s*"
                                     handlebars-mode-handlebars-token
                                     "\s*}}\\)"))
 (defconst handlebars-mode-builtins


### PR DESCRIPTION
Add support for syntax coloring on Handlebars "{{../variable}}" and "{{./variable}}" notation.

See http://handlebarsjs.com#paths for more details.
