### PR TITLE
Add autoload cookies

### DIFF
--- a/handlebars-mode.el
+++ b/handlebars-mode.el
@@ -291,7 +291,9 @@
   (set (make-local-variable 'indent-tabs-mode) nil)
   (set (make-local-variable 'font-lock-defaults) '(handlebars-mode-font-lock-keywords)))
 
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.handlebars$" . handlebars-mode))
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.hbs$" . handlebars-mode))
 
 (provide 'handlebars-mode)


### PR DESCRIPTION
This commit ensures that users who have installed `handlebars-mode` from a Marmalade or MELPA package will be able to automatically turn on `handlebars-mode` when visiting hbs or handlebars files without explicitly requiring the library first.
